### PR TITLE
Add long variable blob test data

### DIFF
--- a/programs/koinos-types/json/test_data.json
+++ b/programs/koinos-types/json/test_data.json
@@ -1,5 +1,9 @@
 [
    {
+      "type": "variable_blob",
+      "json": "z6WWAVR6RaTut2Av6UM6awEwUE5NwgCpoRmC9WQmcjKLWSwQVE6rcRW23MBinCQ1xxPcFgZB9z2jp1igKVp1f6sdJxmf1c9GpMFxi4e1fp7zEJgJrFYD6yrVxqo2kfLAEV8xYYBJPGJTzkKMq7kfZXuTxnoNdPCjqsYDaCvsLsbwdNWgyHW6Ub9K1f5FXZTVobWAsRBNwaXmDRi78ZWz5h5fnUVRnPiq3HHvSu8DBqdxPngorx8rRkswtDsz1KbFyzDTE7W5eFYoAYbszBmkfR2CTHfoT4yZXYkU4YSLPnLGPZeEaMQonDjr3vN35aCcgeHiJq34kVbENgqet8n8cdh2phNEWyRS8ok6A62Ynb5qFnCVzuDqXYHKJCAyrqudpWS2zbRHEivNAe7B6WBuyPUg86mXZEgyGwsEiv517fWQL6hZcj4NfaqNpGsGJMgvUhu6MGgLruphbqQYEpZeLUk3zcfWqGHoVLW3iwi6i9ULDefXvVEU2SdtfkBQi7xGnZurxPxgShbofmx3QxVTLWntL7gB2LGQ2NWtEyUuxrE2h1UKeEDvPjC6dZpNdemDL8FiMQ15nSSnsEj6GEYaPScox6mjCvouw"
+   },
+   {
       "type": "unused_extensions_type",
       "json": {}
    },

--- a/programs/koinos-types/lang/koinos_codegen_cpp/test/main.cpp.j2
+++ b/programs/koinos-types/lang/koinos_codegen_cpp/test/main.cpp.j2
@@ -20,7 +20,7 @@ template< class T >
 void append( const std::string& input, json& arr, std::ofstream& bin )
 {
    T t;
-   koinos::pack::from_json< T >( json::parse(input), t );
+   koinos::pack::from_json( json::parse(input), t );
 
    std::stringstream ss;
    koinos::pack::to_binary( ss, t );


### PR DESCRIPTION
Closes #177

This PR adds a long variable blob to the canonical test data.

The encoded text is Lorem Ipsum

> Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

The length is 445 characters.

The varint encoding is (depending on endianness) either `10000001 01111101` or  `10111110 00000010`.

Because the test passes, both c++ and golang have the same endianness for their varint encoding and no additional changes are needed.

